### PR TITLE
Correcting leap second information element name

### DIFF
--- a/DASH-MPD.xsd
+++ b/DASH-MPD.xsd
@@ -21,7 +21,7 @@
 			<xs:element name="EssentialProperty" type="DescriptorType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="SupplementalProperty" type="DescriptorType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="UTCTiming" type="DescriptorType" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="TimeLeapSecondInformation" type="TimeLeapSecondInformationType" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="LeapSecondInformation" type="LeapSecondInformationType" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="InitializationSet" type="InitializationSetType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="InitializationGroup" type="UIntVWithIDType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="InitializationPresentation" type="UIntVWithIDType" minOccurs="0" maxOccurs="unbounded"/>
@@ -702,7 +702,7 @@
 		</xs:restriction>
 	</xs:simpleType>
 	<!-- Leap Second Information -->
-	<xs:complexType name="TimeLeapSecondInformationType">
+	<xs:complexType name="LeapSecondInformationType">
 		<xs:sequence>
 			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>

--- a/example_G14.mpd
+++ b/example_G14.mpd
@@ -16,5 +16,5 @@
 		</AdaptationSet>
 	</Period>
 	<UTCTiming schemeIdUri="urn:mpeg:dash:utc:http-xsdate:2014" value="https://example.com/iso"/>
-	<TimeLeapSecondInformation availabilityStartLeapOffset="0" nextAvailabilityStartLeapOffset="1" nextLeapChangeTime="2020-01-01T00:00:00"/>
+	<LeapSecondInformation availabilityStartLeapOffset="0" nextAvailabilityStartLeapOffset="1" nextLeapChangeTime="2020-01-01T00:00:00"/>
 </MPD>


### PR DESCRIPTION
There was a copy and paste error when adding the LeapSecondInformation element to the schema (deleted text was copied too making it TimeLeapSecondInformation), and then this was changed in example G14  to match the schema by mistake.  This pull request corrects the element name to the name agreed during MPEG meeting 126 (see 2.7.1 of DASH breakout report m48045 and contribution m46897)