### PR TITLE
Adding type="mixed" to EventType

### DIFF
--- a/DASH-MPD.xsd
+++ b/DASH-MPD.xsd
@@ -93,7 +93,7 @@
 		<xs:attribute name="presentationTimeOffset" type="xs:unsignedLong" default="0"/>
 	</xs:complexType>
 	<!-- Event  -->
-	<xs:complexType name="EventType">
+	<xs:complexType name="EventType" mixed="true">
 		<xs:sequence>
 			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>


### PR DESCRIPTION
As proposed in m47446 in meeting 126 Geneva, and agreed in 2.2.11 of m48045 DASH BoG report at that meeting.  As far as I can tell from the report the proposal to add additional contentEncoding options wasn't gone for, and instead restrictions of text only or xml only would be implemented using spec text.