### PR TITLE
Adding timeShiftBufferDepth attribute to BaseURLType

### DIFF
--- a/DASH-MPD.xsd
+++ b/DASH-MPD.xsd
@@ -645,6 +645,7 @@
 				<xs:attribute name="byteRange" type="xs:string"/>
 				<xs:attribute name="availabilityTimeOffset" type="xs:double"/>
 				<xs:attribute name="availabilityTimeComplete" type="xs:boolean"/>
+				<xs:attribute name="timeShiftBufferDepth" type="xs:duration"/>
 				<xs:anyAttribute namespace="##other" processContents="lax"/>
 			</xs:extension>
 		</xs:simpleContent>


### PR DESCRIPTION
Adds timeShiftBufferDepth attribute to BaseURLType as per meeting 126 DASH BoG Report m48045 section 2.5.2 - taking this from the TuC document for DASH.