### PR TITLE
Last minute 4th edition corrections

### DIFF
--- a/DASH-MPD.xsd
+++ b/DASH-MPD.xsd
@@ -418,23 +418,6 @@
 		<xs:attribute name="source_description" type="xs:string"/>
 		<xs:anyAttribute namespace="##other" processContents="lax"/>
 	</xs:complexType>
-	<!--Request Rate Timeline -->
-	<xs:complexType name="RequestRateTimelineType">
-		<xs:sequence>
-			<xs:element name="RR" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:attribute name="requestRate" type="xs:unsignedLong" use="required"/>
-					<xs:attribute name="s" type="xs:unsignedInt" use="optional"/>
-					<xs:attribute name="r" type="xs:int" use="optional" default="0"/>
-					<xs:anyAttribute namespace="##other" processContents="lax"/>
-				</xs:complexType>
-			</xs:element>
-			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-		</xs:sequence>
-		<xs:attribute name="source" type="xs:string"/>
-		<xs:attribute name="source_description" type="xs:string"/>
-		<xs:anyAttribute namespace="##other" processContents="lax"/>
-	</xs:complexType>
 	<!-- Label and Group Label -->
 	<xs:complexType name="LabelType">
 		<xs:simpleContent>

--- a/example_G11_remote.period.xml
+++ b/example_G11_remote.period.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" minBufferTime="PT1.500000S" type="static" mediaPresentationDuration="PT704S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
 <Period id="1" duration="PT110S" start="PT250S" xmlns="urn:mpeg:dash:schema:mpd:2011">
   <AdaptationSet segmentAlignment="true" maxWidth="1280" maxHeight="720" maxFrameRate="24" par="16:9">
     <Representation id="1" mimeType="video/mp4" codecs="avc1.4d401f" width="1280" height="720" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="927434">
@@ -19,4 +17,3 @@
     </Representation>
   </AdaptationSet>
 </Period>
-</MPD>


### PR DESCRIPTION
Removing xml headers and MPD element from the remote period in G11 and removing the obsolete RequestRateTimelineType from the schema.

All the examples have been validated against the update schema and were valid.  The G11 remote period was checked by pasting it over the period with the xlink in the main part of example G11, and then checking it still validated.

These changes don't need anything doing to the current 4th edition spec text.