### PR TITLE
Make PatchLocation@ttl optional

### DIFF
--- a/DASH-MPD.xsd
+++ b/DASH-MPD.xsd
@@ -146,7 +146,7 @@
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:anyURI">
-				<xs:attribute name="ttl" type="xs:double" use="required"/>
+				<xs:attribute name="ttl" type="xs:double" use="optional"/>
 				<xs:anyAttribute namespace="##other" processContents="lax"/>
 			</xs:extension>
 		</xs:simpleContent>


### PR DESCRIPTION
Adjust's use type of `PatchLocation@ttl` to be optional in line with text statement. See issue #105 for further details.