### PR TITLE
Update and rename example_patch_base.mpd to example_G21_patch_base.mpd

### DIFF
--- a/example_G21_patch_base.mpd
+++ b/example_G21_patch_base.mpd
@@ -11,7 +11,7 @@
     minBufferTime="PT1.0S"
     profiles="urn:mpeg:dash:profile:isoff-live:2011">
 
-    <PatchLocation ttl="60">live-stream/patch.mpd?publishTime=2020-05-13T05%3A34%3A06%2B00%3A00</PatchLocation>
+    <PatchLocation ttl="60">example_G21_patch.mpp?publishTime=2020-05-13T05%3A34%3A06%2B00%3A00</PatchLocation>
 
     <Period id="1588435200" start="PT95725984.571S">
         <AdaptationSet


### PR DESCRIPTION
This is renamed to refer to example G21 and also to address that patch docs have mpp suffix